### PR TITLE
Fix missing sqlite3 import in Dash app

### DIFF
--- a/stock.py
+++ b/stock.py
@@ -7,6 +7,7 @@ import config
 import nyseholidays as nh
 import datetime
 import boto3
+import sqlite3
 
 connection = sqlite3.connect(config.DB_FILE)
 


### PR DESCRIPTION
## Summary
- import `sqlite3` to prevent runtime errors when connecting to DB

## Testing
- `python3 -m py_compile stock.py nyseholidays.py`


------
https://chatgpt.com/codex/tasks/task_e_68541db0af54832e8d6c464e36514ef9